### PR TITLE
Remove XFrameOptionsMiddleware

### DIFF
--- a/eetvoudig/settings.py
+++ b/eetvoudig/settings.py
@@ -53,7 +53,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 ]
 

--- a/eetvoudig/settings.py
+++ b/eetvoudig/settings.py
@@ -53,7 +53,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.security.SecurityMiddleware',
 ]
 
 ROOT_URLCONF = 'eetvoudig.urls'


### PR DESCRIPTION
The XFrameOptionsMiddleware middleware sets the X-Frame-Options header, which we already do in our nginx instance.